### PR TITLE
Fix: 起動時に、OpenFolderを無効 + 「.」が言語の文字小数点区切と違う

### DIFF
--- a/Titalyver2/KaraokeDisplay/AtTagContainer.cs
+++ b/Titalyver2/KaraokeDisplay/AtTagContainer.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 
@@ -62,7 +62,7 @@ namespace Titalyver2
                     }
                     else if (name == "offset")
                     {
-                        if (double.TryParse(value, out double result))
+                        if (double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out double result))
                         {
                             Offset = (result >= 10 || result <= -10) ? result / 1000 : result;
                         }
@@ -76,7 +76,7 @@ namespace Titalyver2
                 if (match.Success)
                 {
                     //[]タグは知らんけど、[offset:ぐらいは読んでやってもいい
-                    if (double.TryParse(match.Groups[1].Value, out double result))
+                    if (double.TryParse(match.Groups[1].Value, NumberStyles.Number, CultureInfo.InvariantCulture, out double result))
                     {
                         Offset = (result >= 10 || result <= -10) ? result / 1000 : result;
                     }

--- a/Titalyver2/KaraokeDisplay/LyricsContainer.cs
+++ b/Titalyver2/KaraokeDisplay/LyricsContainer.cs
@@ -391,7 +391,7 @@ namespace Titalyver2
             Match match = Regex.Match(timetagtext, @"^\[(\d+):(\d+)[:.](\d+)\](.*)$");
             if (match.Success)
             {
-                double second = double.Parse(match.Groups[2].Value + '.' + match.Groups[3].Value);
+                double second = double.Parse(match.Groups[2].Value + '.' + match.Groups[3].Value, CultureInfo.InvariantCulture);
                 StartTime = int.Parse(match.Groups[1].Value) * 60000 + (int)(second * 1000);
                 Text = match.Groups[4].Value;
             }

--- a/Titalyver2/MainWindow.xaml.cs
+++ b/Titalyver2/MainWindow.xaml.cs
@@ -259,7 +259,7 @@ namespace Titalyver2
         private void window_ContextMenuOpening(object sender, System.Windows.Controls.ContextMenuEventArgs e)
         {
             Maximize.IsChecked = WindowState == WindowState.Maximized;
-            OpenFolder.IsEnabled = LyricsSearcher.FilePath != "";
+            OpenFolder.IsEnabled = !String.IsNullOrEmpty(LyricsSearcher.FilePath);
         }
 
         private void Maximize_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
1. happens when the program has just been loaded and there is no available message (no current song = ReadData returns early).

https://github.com/Juna-Idler/Titalyver2/blob/acfe472b4a38b565edeeae3833d12b3ede82630f/Titalyver2/TitalyverMessenger.cs#L252-L262

2. raises a System.FormatException "Input string was not in a correct format" for "59.99" for some European locales

https://github.com/Juna-Idler/Titalyver2/blob/acfe472b4a38b565edeeae3833d12b3ede82630f/Titalyver2/KaraokeDisplay/LyricsContainer.cs#L394